### PR TITLE
Ignore changes on aws_acm_certificate 'options' block

### DIFF
--- a/terraform/modules/acme_certificate/acm.tf
+++ b/terraform/modules/acme_certificate/acm.tf
@@ -7,4 +7,21 @@ resource "aws_acm_certificate" "acm_certificate" {
     Name = "${var.env}-certificate"
     env  = var.env
   }
+
+  # certificate_transparency_logging_preference gets 'DISABLED' value outside of Terraform scope after the creation of
+  # an ACM certificate. When Let's Encrypt certificate is renewed, Terraform marks the ACM certificate to be replaced
+  # as seen below:
+  # - options {
+  #     - certificate_transparency_logging_preference = "DISABLED" -> null # forces replacement
+  #   }
+  # To avoid the replacement of the ACM certificate, we tell Terraform to ignore modifications on 'options' block
+  # see https://www.terraform.io/docs/providers/aws/r/acm_certificate.html#options-configuration-block
+  # Note: Despite the certificate transparency logging being set to 'DISABLED' by AWS, the public
+  # certificates are still being logged in the transparency logs (verified on certificate search service https://crt.sh/)
+  # see https://docs.aws.amazon.com/acm/latest/userguide/acm-concepts.html#concept-transparency
+  lifecycle {
+    ignore_changes = [
+      options,
+    ]
+  }
 }


### PR DESCRIPTION
Ignore changes on aws_acm_certificate 'options' block to avoid the replacement of the ACM certificate by Terraform when renewing an ACME certificate. The ACM certificate cannot be replaced as it may be in use in ALBs.